### PR TITLE
Implement BarberController with DTO, Mapper and Basic Auth setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,24 @@
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		
+		<dependency>
+		    <groupId>org.projectlombok</groupId>
+		    <artifactId>lombok</artifactId>
+		    <version>1.18.32</version>
+		    <scope>provided</scope>
+		</dependency>
+
+		
+		<!-- LOMBOK -->
+		<dependency>
+		    <groupId>org.projectlombok</groupId>
+		    <artifactId>lombok</artifactId>
+		    <optional>true</optional>
+		</dependency>
+
+
+
 
 
         <!-- LOMBOK -->

--- a/src/main/java/com/barbershop/scheduler/config/SecurityConfig.java
+++ b/src/main/java/com/barbershop/scheduler/config/SecurityConfig.java
@@ -2,8 +2,14 @@ package com.barbershop.scheduler.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
@@ -11,5 +17,27 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // Usuário em memória para teste
+    @Bean
+    public UserDetailsService users() {
+        UserDetails admin = User.builder()
+                .username("admin")
+                .password(passwordEncoder().encode("admin123"))
+                .roles("ADMIN")
+                .build();
+        return new InMemoryUserDetailsManager(admin);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf().disable() // desabilita CSRF para facilitar testes
+            .authorizeHttpRequests()
+            .anyRequest().authenticated()
+            .and()
+            .httpBasic(); // habilita Basic Auth
+        return http.build();
     }
 }

--- a/src/main/java/com/barbershop/scheduler/controller/BarberController.java
+++ b/src/main/java/com/barbershop/scheduler/controller/BarberController.java
@@ -1,0 +1,47 @@
+package com.barbershop.scheduler.controller;
+
+import com.barbershop.scheduler.dto.BarberDTO;
+import com.barbershop.scheduler.mapper.BarberMapper;
+import com.barbershop.scheduler.model.Barber;
+import com.barbershop.scheduler.service.BarberService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/barbers")
+public class BarberController {
+
+    private final BarberService barberService;
+
+    public BarberController(BarberService barberService) {
+        this.barberService = barberService;
+    }
+
+    @PostMapping
+    public BarberDTO createBarber(@RequestBody BarberDTO dto) {
+        Barber savedBarber = barberService.saveBarber(BarberMapper.toEntity(dto));
+        return BarberMapper.toDTO(savedBarber);
+    }
+
+    @GetMapping
+    public List<BarberDTO> getAllBarbers() {
+        return barberService.getAllBarbers()
+                .stream()
+                .map(BarberMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/{id}")
+    public BarberDTO getBarberById(@PathVariable Long id) {
+        return barberService.getBarberById(id)
+                .map(BarberMapper::toDTO)
+                .orElseThrow(() -> new RuntimeException("Barber not found"));
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteBarber(@PathVariable Long id) {
+        barberService.deleteBarber(id);
+    }
+}

--- a/src/main/java/com/barbershop/scheduler/dto/BarberDTO.java
+++ b/src/main/java/com/barbershop/scheduler/dto/BarberDTO.java
@@ -1,0 +1,14 @@
+package com.barbershop.scheduler.dto;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class BarberDTO {
+    private Long id;
+    private String name;
+    private String phone;
+    private String specialty;
+}

--- a/src/main/java/com/barbershop/scheduler/mapper/BarberMapper.java
+++ b/src/main/java/com/barbershop/scheduler/mapper/BarberMapper.java
@@ -1,0 +1,25 @@
+package com.barbershop.scheduler.mapper;
+
+import com.barbershop.scheduler.dto.BarberDTO;
+import com.barbershop.scheduler.model.Barber;
+
+public class BarberMapper {
+
+    public static BarberDTO toDTO(Barber barber) {
+        return BarberDTO.builder()
+                .id(barber.getId())
+                .name(barber.getName())
+                .phone(barber.getPhone())
+                .specialty(barber.getSpecialty())
+                .build();
+    }
+
+    public static Barber toEntity(BarberDTO dto) {
+        return Barber.builder()
+                .id(dto.getId())
+                .name(dto.getName())
+                .phone(dto.getPhone())
+                .specialty(dto.getSpecialty())
+                .build();
+    }
+}

--- a/src/main/java/com/barbershop/scheduler/model/Barber.java
+++ b/src/main/java/com/barbershop/scheduler/model/Barber.java
@@ -1,0 +1,20 @@
+package com.barbershop.scheduler.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Barber {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String phone;
+    private String specialty;
+}

--- a/src/main/java/com/barbershop/scheduler/repository/BarberRepository.java
+++ b/src/main/java/com/barbershop/scheduler/repository/BarberRepository.java
@@ -1,0 +1,7 @@
+package com.barbershop.scheduler.repository;
+
+import com.barbershop.scheduler.model.Barber;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BarberRepository extends JpaRepository<Barber, Long> {
+}

--- a/src/main/java/com/barbershop/scheduler/service/BarberService.java
+++ b/src/main/java/com/barbershop/scheduler/service/BarberService.java
@@ -1,0 +1,34 @@
+package com.barbershop.scheduler.service;
+
+import com.barbershop.scheduler.model.Barber;
+import com.barbershop.scheduler.repository.BarberRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class BarberService {
+
+    private final BarberRepository barberRepository;
+
+    public BarberService(BarberRepository barberRepository) {
+        this.barberRepository = barberRepository;
+    }
+
+    public Barber saveBarber(Barber barber) {
+        return barberRepository.save(barber);
+    }
+
+    public List<Barber> getAllBarbers() {
+        return barberRepository.findAll();
+    }
+
+    public Optional<Barber> getBarberById(Long id) {
+        return barberRepository.findById(id);
+    }
+
+    public void deleteBarber(Long id) {
+        barberRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 
 
 spring.jpa.open-in-view=false
+
+spring.security.user.name=admin
+spring.security.user.password=admin123


### PR DESCRIPTION
Implementado BarberController com endpoints para CRUD:
POST /api/barbers – criar barbeiro
GET /api/barbers – listar todos
GET /api/barbers/{id} – buscar por ID
DELETE /api/barbers/{id} – deletar barbeiro
Criado BarberDTO e BarberMapper para separar model e exposição de dados.
Configurado PasswordEncoder no SecurityConfig com BCrypt.
Ajuste no projeto para permitir testes via Postman com autenticação básica.
Incluída camada de service para abstrair lógica do controller.
Testes realizados:
Endpoints de criação, listagem, busca e exclusão testados com Postman.
Autenticação básica configurada e validada.